### PR TITLE
Add Scarf analytics for documentation page view tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,10 @@ const config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
 
+  clientModules: [
+    './src/clientModules/scarfAnalytics.js',
+  ],
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/src/clientModules/scarfAnalytics.js
+++ b/src/clientModules/scarfAnalytics.js
@@ -1,0 +1,24 @@
+// Scarf pixel – SPA-aware tracking for the Docusaurus documentation site.
+// This client module fires on the initial page load and on every subsequent
+// in-app navigation so that each page view is recorded, even in a SPA where
+// the full page is never reloaded.
+
+const PIXEL_ID = '5ff443aa-dd19-43ab-9c9e-ad26252d0fb0';
+
+let lastHref = null;
+
+function sendScarfPing() {
+  const currentHref = window.location.href;
+  if (currentHref === lastHref) return; // dedup: skip if same page
+  lastHref = currentHref;
+
+  const img = new Image();
+  img.referrerPolicy = 'no-referrer-when-downgrade';
+  img.src = `https://static.scarf.sh/a.png?x-pxid=${PIXEL_ID}`;
+}
+
+// Docusaurus client-module lifecycle hook – called after every route update
+// (initial load + every SPA navigation).
+export function onRouteDidUpdate() {
+  sendScarfPing();
+}


### PR DESCRIPTION
Integrates [Scarf](https://docs.scarf.sh/web-traffic/#pixels-and-single-page-application-spa-sites) pixel tracking. Uses a Docusaurus client module with the [onRouteDidUpdate](https://docusaurus.io/docs/advanced/client#client-module-lifecycles) lifecycle hook to fire the tracking pixel on every page view, including SPA client-side navigations.